### PR TITLE
Fix extra whitespace in generated image when scrollbar is present

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -27,7 +27,11 @@ class Result extends React.Component {
 
   genCanvas(){
     const html2canvas = require('html2canvas');
-    window.scrollTo(0,0)
+    window.scrollTo(0,0);
+
+    // Hide scrollbar to fix bug with html2canvas which adds extra whitespace to image if scrollbar is present
+    document.documentElement.style.overflow = 'hidden';
+
     html2canvas(document.querySelector("#preview .tweet-container"), {allowTaint: true, useCORS: true})
     .then((canvas) => {
 
@@ -52,6 +56,9 @@ class Result extends React.Component {
         });
       }
     });
+
+    // Un-hide scrollbar
+    document.documentElement.style.overflow = '';
 
     scroller.scrollTo('canvas')
 


### PR DESCRIPTION
html2canvas seems to have a bug where it adds extra whitespace to the generated image if a scrollbar is present. This can be seen in this screenshot:
![before](https://user-images.githubusercontent.com/15936962/73508905-64eddc00-43ab-11ea-9ffd-b599c854d616.png)

This issue was reported in the [html2canvas repo](https://github.com/niklasvh/html2canvas/issues/1438) and has the suggested solution to hide the scrollbar just when the image is being generated.

I decided to implement that solution and here's how it looks after my change:
![after](https://user-images.githubusercontent.com/15936962/73508906-64eddc00-43ab-11ea-9d65-817f37f6e080.png)

I've tested in Chrome on Windows.